### PR TITLE
Improve wake lock handling and remove gate overlay

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -5,8 +5,6 @@ input[type=range]{width:100%;max-width:400px}
 .pill{background:#eef2ff;padding:6px 12px;border-radius:999px;font-weight:700;font-size:var(--ctrl-size);min-width:var(--pill-min-w);display:inline-flex;align-items:center;justify-content:center}
 .ctrlText{font-size:var(--ctrl-size)}
 #clock{aspect-ratio:1/1;touch-action:none;cursor:pointer}
-#gate{display:none}
-#gate button{padding:14px 18px;font-size:18px;font-weight:800;border:0;border-radius:16px;background:#007aff;color:#fff}
 #actionsSpace{margin:10px 0 12px;height:var(--actions-h);display:flex;justify-content:center;align-items:center;text-align:center}
 #actions{display:none;gap:12px;justify-content:center}
 #preMsg{display:block;font-size:var(--pre-msg-size);font-weight:700;white-space:nowrap}

--- a/index.html
+++ b/index.html
@@ -7,7 +7,6 @@
 <link rel="stylesheet" href="css/style.css">
 </head>
 <body>
-<div id="gate"><button id="gateBtn">タップで開始</button></div>
 <div id="actionsSpace">
   <div id="preMsg">やることを決めてから、タイマーをセットしよう</div>
   <div id="actions">


### PR DESCRIPTION
## Summary
- remove the gate overlay so the timer UI is usable immediately while keeping unlock guards in place
- add wake lock management with a NoSleep fallback and guard against missing gate elements when unlocking
- tie wake lock acquisition/release into visibility changes and the render loop lifecycle

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ca557308388333996b3dc4e492e20b